### PR TITLE
set type of instance variable `@configuration` of `Backtracer::Backtrace::Frame`

### DIFF
--- a/src/backtracer/backtrace/frame.cr
+++ b/src/backtracer/backtrace/frame.cr
@@ -18,7 +18,7 @@ module Backtracer
     protected getter(configuration) { Backtracer.configuration }
 
     def initialize(@method, @path = nil, @lineno = nil, @column = nil, *,
-                   @configuration = nil)
+                   @configuration : Backtracer::Configuration? = nil)
     end
 
     def_equals_and_hash @method, @path, @lineno, @column


### PR DESCRIPTION
Fixes:

```
Showing last frame. Use --error-trace for full trace.                                                                                                                                        
                                                                                                                                                                                             
In src/backtracer/backtrace/frame.cr:21:20                                                                                                                                                   
                                                                                                                                                                                             
 21 | @configuration = nil)                                                                                                                                                                  
      ^                                                                                                                                                                                      
Error: instance variable @configuration of Backtracer::Backtrace::Frame was inferred to be Nil, but Nil alone provides no information  
```

```
crystal -v
Crystal 1.16.0-dev [4d0306e5d] (2025-03-15)

LLVM: 18.1.6
Default target: x86_64-unknown-linux-gnu
```